### PR TITLE
feat : add fontfamily configuration to tailwind config file

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,5 +8,11 @@ module.exports = (isProd) => ({
       enabled: isProd,
       content: ['**/*.html', '**/*.ts']
     },
-    theme: {}
+    theme: {
+        fontFamily: {
+          display: ['Inter', 'sans-serif'],
+          body: ['Inter', 'sans-serif'],
+          sans: ['Inter', 'sans-serif'],
+        }
+    }
 });


### PR DESCRIPTION
En mi local la fuente era inter, pero inspeccionando en la página que tenemos desplegada no es inter. Con esta config debería tomar la fuente Inter siempre