### PR TITLE
Add Inter Font from API Google Update styles.scss

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,5 @@
 @import 'tailwindcss/base';
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;900;800&display=swap');
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 /* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
Instalando en Tailwind base la fuente, hacemos un llamado a la Api de google Font y no deberá visualizar la fuente:
Tamaño: 200 hasta 900. Si se instala solo algunos tamaños se debe hacer así: 400;500;600;800

Pueden probarlo antes de subir, Gracias